### PR TITLE
To internal tests

### DIFF
--- a/asdf_zarr/converter.py
+++ b/asdf_zarr/converter.py
@@ -39,7 +39,7 @@ class ZarrConverter(asdf.extension.Converter):
             if asdf_key is None:
                 asdf_key = ctx.generate_block_key()
             obj_dict["chunk_block_map"] = ctx.find_available_block_index(
-               storage._generate_chunk_map_callback(obj, chunk_key_block_index_map), asdf_key
+                storage._generate_chunk_map_callback(obj, chunk_key_block_index_map), asdf_key
             )
             return obj_dict
 
@@ -75,7 +75,7 @@ class ZarrConverter(asdf.extension.Converter):
             return obj
 
         chunk_store = util.decode_storage(node["store"])
-        if "meta" in node:
+        if "meta_store" in node:
             # separate meta and chunk stores
             store = util.decode_storage(node["meta_store"])
         else:

--- a/asdf_zarr/converter.py
+++ b/asdf_zarr/converter.py
@@ -32,14 +32,14 @@ class ZarrConverter(asdf.extension.Converter):
             chunk_key_block_index_map = {}
             for chunk_key in storage._iter_chunk_keys(obj, only_initialized=True):
                 data_callback = storage._generate_chunk_data_callback(obj, chunk_key)
-                asdf_key = chunk_store._chunk_asdf_keys.get(chunk_key, asdf.util.BlockKey())
-                block_index = ctx.find_block_index(asdf_key, data_callback)
+                asdf_key = chunk_store._chunk_asdf_keys.get(chunk_key, ctx.generate_block_key())
+                block_index = ctx.find_available_block_index(data_callback, asdf_key)
                 chunk_key_block_index_map[chunk_key] = block_index
             asdf_key = chunk_store._chunk_block_map_asdf_key
             if asdf_key is None:
-                asdf_key = asdf.util.BlockKey()
-            obj_dict["chunk_block_map"] = ctx.find_block_index(
-                asdf_key, storage._generate_chunk_map_callback(obj, chunk_key_block_index_map)
+                asdf_key = ctx.generate_block_key()
+            obj_dict["chunk_block_map"] = ctx.find_available_block_index(
+               storage._generate_chunk_map_callback(obj, chunk_key_block_index_map), asdf_key
             )
             return obj_dict
 

--- a/asdf_zarr/storage.py
+++ b/asdf_zarr/storage.py
@@ -2,7 +2,6 @@ import itertools
 import json
 import math
 
-import asdf
 import numpy
 import zarr
 
@@ -61,7 +60,7 @@ def to_internal(zarray):
         return zarray
     # make a new internal store based off an existing store
     internal_store = ConvertedInternalStore(zarray.chunk_store or zarray.store)
-    return zarr.open(internal_store)
+    return zarr.open(zarray.store, chunk_store=internal_store)
 
 
 class InternalStore(zarr.storage.Store):

--- a/asdf_zarr/storage.py
+++ b/asdf_zarr/storage.py
@@ -139,11 +139,10 @@ class ReadInternalStore(InternalStore):
         # split into 4 chunks) the chunk_block_map will be
         # 4 x 5
         cdata_shape = tuple(math.ceil(s / c) for s, c in zip(zarray_meta["shape"], zarray_meta["chunks"]))
+        self._chunk_block_map_asdf_key = ctx.generate_block_key()
         self._chunk_block_map = numpy.frombuffer(
-            ctx.get_block_data_callback(chunk_block_map_index)(), dtype="int32"
+            ctx.get_block_data_callback(chunk_block_map_index, self._chunk_block_map_asdf_key)(), dtype="int32"
         ).reshape(cdata_shape)
-        self._chunk_block_map_asdf_key = asdf.util.BlockKey()
-        ctx.assign_block_key(chunk_block_map_index, self._chunk_block_map_asdf_key)
 
         self._chunk_block_map_asdf_key = None
 
@@ -154,10 +153,9 @@ class ReadInternalStore(InternalStore):
             coord = tuple(coord)
             block_index = int(self._chunk_block_map[coord])
             chunk_key = self._sep.join((str(c) for c in tuple(coord)))
-            asdf_key = asdf.util.BlockKey()
+            asdf_key = ctx.generate_block_key()
             self._chunk_asdf_keys[chunk_key] = asdf_key
-            ctx.assign_block_key(block_index, asdf_key)
-            self._chunk_callbacks[chunk_key] = ctx.get_block_data_callback(block_index)
+            self._chunk_callbacks[chunk_key] = ctx.get_block_data_callback(block_index, asdf_key)
 
     def _sep_key(self, key):
         if self._sep is None:


### PR DESCRIPTION
Add tests for `to_internal` (moving an externally stored zarr array to 'internal' ASDF blocks).

This revealed a few issues with how this extension was controlling ASDF blocks (using an older version of the API) that are fixed in this PR.