### PR TITLE
Allow `ReadInternalStore` to be pickled

### DIFF
--- a/asdf_zarr/storage.py
+++ b/asdf_zarr/storage.py
@@ -2,6 +2,7 @@ import itertools
 import json
 import math
 
+import asdf
 import numpy
 import zarr
 
@@ -155,6 +156,36 @@ class ReadInternalStore(InternalStore):
             asdf_key = ctx.generate_block_key()
             self._chunk_asdf_keys[chunk_key] = asdf_key
             self._chunk_callbacks[chunk_key] = ctx.get_block_data_callback(block_index, asdf_key)
+
+    def __getstate__(self):
+        state = {}
+        state["_sep"] = self._sep
+
+        # for each callback, get the file uri and block offset
+        def _callback_info(cb):
+            return {
+                "offset": cb(_attr="offset"),
+                "uri": cb(_attr="_fd")().uri,
+            }
+
+        state["_chunk_callbacks"] = {k: _callback_info(self._chunk_callbacks[k]) for k in self._chunk_callbacks}
+        return state
+
+    def __setstate__(self, state):
+        self._sep = state["_sep"]
+
+        def _to_callback(info):
+            def cb():
+                with asdf.generic_io.get_file(info["uri"], mode="r") as gf:
+                    return asdf._block.io.read_block(gf, info["offset"])[-1]
+
+            return cb
+
+        self._chunk_callbacks = {k: _to_callback(state["_chunk_callbacks"][k]) for k in state["_chunk_callbacks"]}
+        # as __init__ will not be called on self, set up attributed expected
+        # due to the parent InternalStore class
+        self._tmp_store_ = None
+        self._deleted_keys = set()
 
     def _sep_key(self, key):
         if self._sep is None:


### PR DESCRIPTION
To use a zarr array read from an asdf file (with chunks stored as internal ASDF blocks) with dask distributed processing the store that provides the chunk data must be pickleable.

This PR makes `ReadInternalStore` pickleable (and re-pickleable as dask may transfer chunks between workers).

The following example was used for prototyping:
```python
import os

import asdf
import dask.distributed
import dask.array
import zarr
import numpy as np

import asdf_zarr.storage


if __name__ == '__main__':
    fn = 'big_test.asdf'

    if not os.path.exists(fn):
        shape = (17000, 37000)  # 600 MB
        a = np.arange(np.product(shape), dtype='uint8').reshape(shape)
        z = zarr.array(a, chunks=(1000, 1000), compressor=None)
        af = asdf.AsdfFile()
        af['z'] = asdf_zarr.storage.to_internal(z)
        af.write_to(fn)


    client = dask.distributed.Client()
    print(f"client at {client.dashboard_link}")


    with asdf.open(fn) as af:
        z = af['z']
        d = dask.array.from_zarr(z)
        input("press enter to compute sum")
        print("Computing sum...")
        s = d.sum().compute()
        print(f"\tsum={s}")
        input("press enter to exit")
```

The above example generates a large (17k x 37k) image, saves it to an ASDF file as a chunked array, loads the saved file, converts the chunked array to a dask array and computes the sum (using dask distributed). The screenshot below is of a single run showing the computation distributed across 10 workers.

<img width="1069" alt="Screen Shot 2023-10-17 at 5 17 07 PM" src="https://github.com/asdf-format/asdf-zarr/assets/114267/2f2bba7a-7e64-4489-811e-3cae34e842fb">

As it's likely that users will want to use dask we should consider options for testing dask compatibility (and specifically dask distributed compatibility) in the CI.