### PR TITLE
pin zarr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,3 +2,4 @@
 ------------------
 
 - added changelog [#36]
+- pin zarr to < 3 until the 3.x API is stable [#43]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dynamic = [
 ]
 dependencies = [
   "asdf >= 3.0.0",
-  "zarr >= 2.14",
+  "zarr >= 2.14, < 3.0.0",
   "fsspec",
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 git+https://github.com/asdf-format/asdf
-git+https://github.com/zarr-developers/zarr-python/
+#git+https://github.com/zarr-developers/zarr-python/
 git+https://github.com/fsspec/filesystem_spec/
 
 # Use Bi-weekly numpy/scipy dev builds


### PR DESCRIPTION
Zarr v3 is planned for release in June: https://github.com/zarr-developers/zarr-python/issues/1777
It includes major API changes which will break this extension (see https://github.com/asdf-format/asdf-zarr/actions/runs/9227086826/job/25388325700).

This PR pins zarr to "<3" and removes it from the devdeps (so that we can at least test our other dependencies).

Once the v3 API is finalized this package can be updated to possibly support both <3 and >=3 versions or support for <3 can be dropped.