### PR TITLE
replace usages of ``copy_arrays`` with ``memmap``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.1.0 (unreleased)
 ------------------
 
--
+- replace usages of ``copy_arrays`` with ``memmap`` [#46]
 
 0.0.4 (2024-06-28)
 ------------------

--- a/notebooks/ASDF_array_storage_intro.ipynb
+++ b/notebooks/ASDF_array_storage_intro.ipynb
@@ -623,7 +623,7 @@
     "\n",
     "For local files, asdf will memory map arrays allowing the operating system to read only the portion of the array that is requested.\n",
     "\n",
-    "Note that array memory mapping can be disabled by setting the keyword argument `copy_arrays` to `True` in `asdf.open`."
+    "Note that array memory mapping can be disabled by setting the keyword argument `memmap` to `False` in `asdf.open`."
    ]
   },
   {
@@ -641,7 +641,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "With default copy_arrays=False\n",
+      "With default memmap=True\n",
       "\tarray 0 base array type = <class 'numpy.memmap'>\n"
      ]
     }
@@ -649,7 +649,7 @@
    "source": [
     "# open our example file with memory mapping (enabled by default)\n",
     "with asdf.open(example_fn) as af:\n",
-    "    print(\"With default copy_arrays=False\") \n",
+    "    print(\"With default memmap=True\") \n",
     "    # the array data has a base array that is of type numpy.memmap\n",
     "    print(f\"\\tarray 0 base array type = {type(af['array0'].base)}\")"
    ]
@@ -669,15 +669,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "With copy_arrays=True\n",
+      "With memmap=False\n",
       "\tarray 0 base array type = <class 'numpy.ndarray'>\n"
      ]
     }
    ],
    "source": [
     "# open our example file with memory mapping disabled\n",
-    "with asdf.open(example_fn, copy_arrays=True) as af:\n",
-    "    print(\"With copy_arrays=True\")\n",
+    "with asdf.open(example_fn, memmap=False) as af:\n",
+    "    print(\"With memmap=False\")\n",
     "    print(f\"\\tarray 0 base array type = {type(af['array0'].base)}\")"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dynamic = [
   'version',
 ]
 dependencies = [
-  "asdf >= 3.0.0",
+  "asdf >= 3.1.0",
   "zarr >= 2.14, < 3.0.0",
   "fsspec",
 ]


### PR DESCRIPTION
follow-on to https://github.com/asdf-format/asdf/pull/1797