### PR TITLE
configure dependabot to ignore dev requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,13 @@ updates:
     directory: "/"
     target-branch: "main"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
   # Maintain dependencies for pip (main)
   - package-ecosystem: "pip"
     directory: "/"
     target-branch: "main"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    exclude-paths:
+      - "requirements-dev.txt"

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     coverage: pytest-cov
     parallel: pytest-xdist
     devdeps: -rrequirements-dev.txt
-extras = all,tests
+extras = tests
 # astropy will complain if the home directory is missing
 pass_env = HOME
 package = editable


### PR DESCRIPTION
Also sets these updates to monthly given the low traffic nature of this package.

This also includes a minor update to the tox.ini removing the attempt to install a non-existent "all" extra (which is causing tox to fail with recent versions).